### PR TITLE
improve UI for selection meteo model of hydraulic scheme

### DIFF
--- a/src/gui/hydraulicNetwork/reoshydraulicnetworkwidget.h
+++ b/src/gui/hydraulicNetwork/reoshydraulicnetworkwidget.h
@@ -39,6 +39,7 @@ class ReosGeometryStructure;
 class ReosStructure2dToolBar;
 class ReosHydraulicElementModel;
 class ReosAddHydrographNodeFromWidget;
+class ReosHydraulicSchemeWidget;
 
 class REOSGUI_EXPORT ReosHydraulicElementWidget : public QWidget
 {
@@ -59,8 +60,7 @@ class REOSGUI_EXPORT ReosHydraulicNetworkWidget : public QWidget
 {
     Q_OBJECT
   public:
-    explicit ReosHydraulicNetworkWidget( ReosHydraulicNetwork *network,
-                                         ReosWatershedModule *watershedModule,
+    explicit ReosHydraulicNetworkWidget(ReosHydraulicNetwork *network,
                                          const ReosGuiContext &context );
     ~ReosHydraulicNetworkWidget();
 
@@ -100,8 +100,6 @@ class REOSGUI_EXPORT ReosHydraulicNetworkWidget : public QWidget
 
     void onMapCrsChanged();
 
-    void onMeteoModelChanged();
-
   private:
     Ui::ReosHydraulicNetworkWidget *ui;
     ReosGuiContext mGuiContext;
@@ -111,6 +109,7 @@ class REOSGUI_EXPORT ReosHydraulicNetworkWidget : public QWidget
     ReosHydraulicNetworkElement *mCurrentSelectedElement = nullptr;
     ReosHydraulicScheme *mCurrentHydraulicScheme = nullptr;
     ReosStructure2dToolBar *mStructure2dToolBar = nullptr;
+    ReosHydraulicSchemeWidget *mSchemeWidget = nullptr;
 
     typedef std::shared_ptr<ReosMapItem> NetworkItem ;
 
@@ -158,8 +157,7 @@ class REOSGUI_EXPORT ReosHydraulicNetworkDockWidget: public ReosDockWidget
 {
     Q_OBJECT
   public:
-    ReosHydraulicNetworkDockWidget( ReosHydraulicNetwork *network,
-                                    ReosWatershedModule *watershedModule,
+    ReosHydraulicNetworkDockWidget(ReosHydraulicNetwork *network,
                                     const ReosGuiContext &context );
 
     void closePropertieWidget();

--- a/src/gui/hydraulicNetwork/reoshydraulicschemewidget.h
+++ b/src/gui/hydraulicNetwork/reoshydraulicschemewidget.h
@@ -25,6 +25,7 @@
 class ReosHydraulicScheme;
 class ReosHydraulicNetworkContext;
 class ReosHydraulicNetwork;
+class ReosMeteorologicModelsCollection;
 
 namespace Ui
 {
@@ -36,10 +37,15 @@ class ReosHydraulicSchemeWidget : public QWidget
     Q_OBJECT
 
   public:
-    explicit ReosHydraulicSchemeWidget( ReosHydraulicScheme *scheme, const ReosHydraulicNetworkContext &context, QWidget *parent = nullptr );
+    explicit ReosHydraulicSchemeWidget( const ReosHydraulicNetworkContext &context, QWidget *parent = nullptr );
     ~ReosHydraulicSchemeWidget();
 
     void setScheme( ReosHydraulicScheme *scheme );
+
+    void hideName();
+
+  signals:
+    void meteoModelChange( const QString &meteoName );
 
   private slots:
     void onMeteoModelChange();
@@ -47,25 +53,7 @@ class ReosHydraulicSchemeWidget : public QWidget
   private:
     Ui::ReosHydraulicSchemeWidget *ui;
     ReosHydraulicScheme *mScheme = nullptr;
-    ReosHydraulicNetworkContext mContext;
-};
-
-
-class ReosHydraulicSchemeWidgetAction : public QWidgetAction
-{
-    Q_OBJECT
-  public:
-    ReosHydraulicSchemeWidgetAction( ReosHydraulicNetwork *network, QObject *parent = nullptr );
-
-    void setCurrentScheme( ReosHydraulicScheme *scheme );
-
-  protected:
-    QWidget *createWidget( QWidget *parent ) override;
-
-  private:
-    ReosHydraulicNetwork *mNetwork = nullptr;
-    ReosHydraulicScheme *mScheme = nullptr;
-    ReosHydraulicSchemeWidget *mWidget = nullptr;
+    ReosMeteorologicModelsCollection *mMeteoCollection = nullptr;
 };
 
 
@@ -77,7 +65,7 @@ class ReosHydraulicSchemeListView : public QListView
     void setSchemeCollection( ReosHydraulicSchemeCollection *collection );
 
     ReosHydraulicScheme *currentScheme() const;
-    void setCurrentScheme(const QString &schemeId );
+    void setCurrentScheme( const QString &schemeId );
 
   private:
     ReosHydraulicSchemeCollection *mCollection = nullptr;

--- a/src/lekan/lekanmainwindow.cpp
+++ b/src/lekan/lekanmainwindow.cpp
@@ -91,7 +91,7 @@ LekanMainWindow::LekanMainWindow( ReosCoreModule *core, QWidget *parent )
   mGisDock->setObjectName( QStringLiteral( "gisDock" ) );
   mGisDock->setWidget( new ReosGisLayersWidget( mCore->gisEngine(), mMap, this ) );
 
-  mDockHydraulicNetwork = new ReosHydraulicNetworkDockWidget( mCore->hydraulicNetwork(), mCore->watershedModule(), guiContext );
+  mDockHydraulicNetwork = new ReosHydraulicNetworkDockWidget( mCore->hydraulicNetwork(), guiContext );
   mDockHydraulicNetwork->setObjectName( QStringLiteral( "hydraulicDock" ) );
 
   mHydraulicNetworkWidget = mDockHydraulicNetwork->hydraulicNetworkWidget();

--- a/src/ui/reoshydraulicnetworkwidget.ui
+++ b/src/ui/reoshydraulicnetworkwidget.ui
@@ -70,10 +70,42 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item row="2" column="1">
-       <widget class="QComboBox" name="mMeteoModelCombo"/>
+      <item row="1" column="0" colspan="3">
+       <widget class="Line" name="line_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
       </item>
-      <item row="0" column="0" colspan="2">
+      <item row="3" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Meteorologic model</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="mMeteoModelLabel">
+        <property name="text">
+         <string notr="true">TextLabel</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QToolButton" name="mSchemeSettingsButton">
+        <property name="text">
+         <string>...</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../images/images.qrc">
+          <normaloff>:/images/settings.svg</normaloff>:/images/settings.svg</iconset>
+        </property>
+        <property name="autoRaise">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="3">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <property name="topMargin">
          <number>0</number>
@@ -128,21 +160,7 @@
         </item>
        </layout>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Meteorologic model</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="Line" name="line_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0" colspan="2">
+      <item row="4" column="0" colspan="3">
        <widget class="Line" name="line_3">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>

--- a/src/ui/reoshydraulicschemewidget.ui
+++ b/src/ui/reoshydraulicschemewidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>301</width>
-    <height>92</height>
+    <width>287</width>
+    <height>111</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,10 +15,28 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="ReosParameterStringWidget" name="mWidetName" native="true"/>
+    <widget class="QWidget" name="mNameWidget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="ReosParameterStringWidget" name="mParameterNameWidget" native="true"/>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
-    <widget class="Line" name="line">
+    <widget class="Line" name="mNameSeprator">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>


### PR DESCRIPTION
In the hydraulic network widget, selection Meteo model and hydraulic scheme is confusing as we have two combo box for it. With this changes, we hide the combo box of the meteo model. User has to push a button to have access to it.

Before:
![image](https://github.com/vcloarec/ReosProject/assets/7416892/e104c21a-6ebb-4e0d-9cc0-2c75dac2768e)

After:
![meteo_select](https://github.com/vcloarec/ReosProject/assets/7416892/9063ead0-2238-4822-9989-a51fb0f1cd50)

